### PR TITLE
Removed unused parameter

### DIFF
--- a/src/Command/MediaOptimizeCommand.php
+++ b/src/Command/MediaOptimizeCommand.php
@@ -113,7 +113,7 @@ class MediaOptimizeCommand extends Command
 
         while (($result = $mediaIterator->fetch()) !== null) {
             foreach ($result->getEntities() as $media) {
-                $this->optimize($media, $context);
+                $this->optimize($media);
                 $progressBar->advance();
             }
         }


### PR DESCRIPTION
```
private function optimize(MediaEntity $media): void
```
Does not expect the context